### PR TITLE
i#1 Set max width of title and clean up

### DIFF
--- a/components/FarmCollectionCard/FarmCollectionCard.tsx
+++ b/components/FarmCollectionCard/FarmCollectionCard.tsx
@@ -9,6 +9,8 @@ import NumberFormat from 'react-number-format';
 import getCollectionExpireDate from 'helpers/gemFarm';
 import * as styles from './FarmCollectionCard.css';
 
+const maxNameLength = 25;
+
 // TODO: Uncomment bellow code to make component accept props
 
 // interface Props {
@@ -25,6 +27,8 @@ const FarmCollectionCard = (props: any) => {
     newFarmData.data.eventDuration
   );
 
+  const projectName = (name: string): string => name?.length > maxNameLength ? `${name.substring(0, maxNameLength).trim()}...` : name;
+
   return (
     <Box
       backgroundColor="backgroundTertiary"
@@ -32,6 +36,7 @@ const FarmCollectionCard = (props: any) => {
       borderRadius="2xLarge"
       width="full"
       className={styles.cardContainer}
+      title={newFarmData.data.name}
     >
       <Stack>
         <Box paddingBottom="3">
@@ -53,14 +58,13 @@ const FarmCollectionCard = (props: any) => {
                   variant="large"
                   ellipsis
                   lineHeight="none"
-                  whiteSpace="pre-wrap"
+                  whiteSpace="nowrap"
                 >
                   {' '}
-                  {newFarmData.data.name}
+                  {projectName(newFarmData.data.name)}
                 </Text>
               </Box>
             </Stack>
-            <Tag tone="accent">V3</Tag>
           </Stack>
         </Box>
         <Stack>

--- a/components/FarmCollectionCard/FarmCollectionCard.tsx
+++ b/components/FarmCollectionCard/FarmCollectionCard.tsx
@@ -9,7 +9,7 @@ import NumberFormat from 'react-number-format';
 import getCollectionExpireDate from 'helpers/gemFarm';
 import * as styles from './FarmCollectionCard.css';
 
-const maxNameLength = 25;
+const maxNameLength = 20;
 
 // TODO: Uncomment bellow code to make component accept props
 


### PR DESCRIPTION
closes #1 (potentially)

Here's my stab at a first PR. Took number #1 as it was low hanging. Didn't see an obvious nice way with degen UI to set a max width in CSS, used JS instead. You guys may have a better way of doing this that I'm familiar with! I suspect you do, as this solution doesn't take into consideration media widths. However, we could fix 5 items on the row at max width with this.

I also opted to remove `v3` label as I'm not sure its needed given the header stating the same, and takes up title space.

Current display:
![image](https://user-images.githubusercontent.com/2805752/160302351-208640f3-4b67-43f4-93b1-87cbe24c45fe.png)

If we had a long name project:
![image](https://user-images.githubusercontent.com/2805752/160302466-0bc654d8-e6e9-4d00-8993-77dc6052b82d.png)

