### PR TITLE
refactor(collection-card): add line-clamp style to title, always show allocation on two lines

### DIFF
--- a/components/FarmCollectionCard/FarmCollectionCard.css.ts
+++ b/components/FarmCollectionCard/FarmCollectionCard.css.ts
@@ -10,3 +10,9 @@ export const cardContainer = style({
     borderColor: vars.colors.foregroundSecondary
   }
 });
+
+export const cardTitle = style({
+  WebkitLineClamp: 1,
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical'
+});

--- a/components/FarmCollectionCard/FarmCollectionCard.tsx
+++ b/components/FarmCollectionCard/FarmCollectionCard.tsx
@@ -55,8 +55,13 @@ const FarmCollectionCard = (props: any) => {
                   lineHeight="none"
                   whiteSpace="pre-wrap"
                 >
-                  {' '}
-                  {newFarmData.data.name}
+                  <div
+                    className={styles.cardTitle}
+                    title={newFarmData.data.name}
+                  >
+                    {' '}
+                    {newFarmData.data.name}
+                  </div>
                 </Text>
               </Box>
             </Stack>
@@ -73,9 +78,9 @@ const FarmCollectionCard = (props: any) => {
             >
               Allocation per NFT:
             </Text>
-            <Text align="right" weight="medium">
-              {newFarmData.data.allocation} ${newFarmData.data.rewardTokenName}
-              /day
+            <Text align="right" weight="medium" whiteSpace="pre-wrap">
+              {newFarmData.data.allocation}
+              {'\n'}${newFarmData.data.rewardTokenName}/day
             </Text>
           </Stack>
           <Stack direction="horizontal" align="center" justify="space-between">


### PR DESCRIPTION
Hey @tinybigideas! I saw your PR for #1 as I was browsing the issues trying to see if I could contribute. I was able to find a workaround with CSS involving using `webkit-line-clamp`, curious to get your (and the team's) thoughts. I also opted to add a small change to the way allocation per nft is displayed so that it shows up on 2 lines always to avoid card height mismatches (see yellow boxes in screenshots below). I saw that you added the title property so that the user could see the entire title if they hover over it (nice touch), I added that in this PR as well. I left the V3 tag in here, but I agree with you that it seems kind of redundant (and could be removed).

Before:
<img width="972" alt="Screen Shot 2022-04-03 at 6 41 37 AM" src="https://user-images.githubusercontent.com/102900016/161424236-a55f8933-f686-44c3-8ce9-abc153b53eb7.png">

After:
<img width="902" alt="Screen Shot 2022-04-03 at 6 39 57 AM" src="https://user-images.githubusercontent.com/102900016/161424272-7ef60e41-5e49-4456-8126-20254936d0de.png">

