### PR TITLE
feat(farm): add stake/unstake using `sendAll`

### DIFF
--- a/hooks/useGemFarm.tsx
+++ b/hooks/useGemFarm.tsx
@@ -247,6 +247,10 @@ const useGemFarm = () => {
     setSelectedWalletNFTs([...selectedWalletNFTs, NFT]);
   };
 
+  const onWalletNFTSelectAll = async () => {
+    setSelectedWalletNFTs(Object.values(walletNFTsInFarm));
+  };
+
   const onWalletNFTUnselect = (NFT: NFT) => {
     const newSelected = selectedWalletNFTs.filter(
       nft => !(nft.tokenId.toString() === NFT.tokenId.toString())
@@ -256,6 +260,10 @@ const useGemFarm = () => {
 
   const onStakedNFTSelect = (NFT: NFT) => {
     setSelectedVaultNFTs([...selectedVaultNFTs, NFT]);
+  };
+
+  const onStakedNFTSelectAll = async () => {
+    setSelectedVaultNFTs(Object.values(stakedNFTsInFarm));
   };
 
   const onStakedNFTUnselect = (unselectedNFT: NFT) => {
@@ -545,8 +553,10 @@ const useGemFarm = () => {
     initializeFarmerAcc,
     refreshNFTsWithLoadingIcon,
     onWalletNFTSelect,
+    onWalletNFTSelectAll,
     onWalletNFTUnselect,
     onStakedNFTSelect,
+    onStakedNFTSelectAll,
     onStakedNFTUnselect,
     handleRefreshRewardsButtonClick,
     handleStakeButtonClick,

--- a/pages/farm/[name]/index.tsx
+++ b/pages/farm/[name]/index.tsx
@@ -11,8 +11,10 @@ import { useState } from 'react';
 const Nft: NextPage = () => {
   const {
     onWalletNFTSelect,
+    onWalletNFTSelectAll,
     onWalletNFTUnselect,
     onStakedNFTSelect,
+    onStakedNFTSelectAll,
     onStakedNFTUnselect,
     initializeFarmerAcc,
     handleStakeButtonClick,
@@ -76,6 +78,15 @@ const Nft: NextPage = () => {
           title="Select your NFTs"
           buttons={[
             {
+              title: `Select All`,
+              disabled: !farmerAcc
+                ? false
+                : Object.values(walletNFTsInFarm).length > 0
+                ? false
+                : true,
+              onClick: () => onWalletNFTSelectAll()
+            },
+            {
               title: !farmerAcc
                 ? 'Initialize'
                 : `Stake ( ${selectedWalletNFTs.length} )`,
@@ -100,6 +111,11 @@ const Nft: NextPage = () => {
           isFetching={isFetching}
           title="Your vault"
           buttons={[
+            {
+              title: `Select All`,
+              disabled: Object.values(stakedNFTsInFarm).length < 1,
+              onClick: () => onStakedNFTSelectAll()
+            },
             {
               title: `Unstake (${selectedVaultNFTs.length})`,
               disabled: !selectedVaultNFTs.length,


### PR DESCRIPTION
Add staking/unstaking using multiple transactions and
`Provider.sendAll()` when the number of NFTs is too large to send in a
single transaction.