### PR TITLE
feat(farm): add stake vault button

### DIFF
--- a/components/FarmHeaderComponent/FarmHeaderComponent.tsx
+++ b/components/FarmHeaderComponent/FarmHeaderComponent.tsx
@@ -10,7 +10,11 @@ const FarmHeaderComponent = () => {
     collectionTotalNumber,
     rewardTokenName,
     handleRefreshRewardsButtonClick,
-    claimRewards
+    claimRewards,
+    farmerState,
+    stakedNFTsInFarm,
+    farmerVaultLocked,
+    lockVault
   } = useGemFarm();
 
   const [txLoading, setTxLoading] = useState({
@@ -105,6 +109,14 @@ const FarmHeaderComponent = () => {
               {farmerCount}
             </Text>
           </Stack>
+          <Stack direction="vertical" space="1" align="center">
+            <Text size="small" align="center" variant="label">
+              Your vault
+            </Text>
+            <Text size="small" variant="small">
+              {farmerState}
+            </Text>
+          </Stack>
           {Boolean(unstakingFee) && (
             <Stack direction="vertical" space="1" align="center">
               <Text align="center" variant="label">
@@ -118,7 +130,6 @@ const FarmHeaderComponent = () => {
         </Stack>
         <Stack space="3" justify="center" direction="horizontal">
           <Button
-            
             onClick={handleRefreshRewardsButtonClick}
             variant="secondary"
             shape="square"
@@ -134,6 +145,18 @@ const FarmHeaderComponent = () => {
           >
             {`Claim $${rewardTokenName}`}
           </Button>
+          {(Object.values(stakedNFTsInFarm).length > 0 &&
+            !farmerVaultLocked) && (
+            <Button
+              onClick={() => withTxLoading(lockVault, 'stake')}
+              loading={txLoading.value && txLoading.txName === 'stake'}
+              size="small"
+              tone="green"
+              variant="primary"
+            >
+              {`Stake Vault`}
+            </Button>
+          )}
         </Stack>
       </Stack>
     </Box>

--- a/hooks/useGemFarm.tsx
+++ b/hooks/useGemFarm.tsx
@@ -495,6 +495,7 @@ const useGemFarm = () => {
       const tx = new Transaction();
       tx.add(await gf!.stakeWalletIx(new PublicKey(farmAddress!)));
       await gf!.provider.sendAndConfirm!(tx);
+      await fetchFarmerDetails(gf, gb);
     }
   };
 
@@ -569,6 +570,7 @@ const useGemFarm = () => {
 
   return {
     claimRewards,
+    lockVault,
     initializeFarmerAcc,
     refreshNFTsWithLoadingIcon,
     onWalletNFTSelect,


### PR DESCRIPTION
This provides a fallback mechanism for when a farmer deposits NFTs to
their vault but the stake transaction is not sent/confirmed.
In this case, this allows the farmer to stake their vault manually.