### PR TITLE
Add security headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,29 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "geolocation=(self), microphone=()"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds security headers via `vercel.json` to protect the frontend from certain attacks.

For more details, check the resources.

## Resources
* https://blakey.co/blog/setting-up-security-headers-with-vercel
* https://securityheaders.com/
* https://vercel.com/docs/project-configuration#project-configuration/headers